### PR TITLE
cache and precompute option for grid descriptors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ conda env create -f environment.yaml && conda activate limosat
 ## Run limosat
 1.	Prepare Your Data:
 Organize your satellite imagery into a folder and run `preprocessing.py`.
+   If you use the gridded descriptor cache, note that changing stride or descriptor
+   parameters (ORB settings, border size, octave) requires regenerating the cache.
 2. Build catalog:
 Use create_image_gdf to build a catalog of imagery metadata.
 3.	Set-up database(optional):

--- a/limosat/image_processor.py
+++ b/limosat/image_processor.py
@@ -43,6 +43,7 @@ class ImageProcessor:
                  insitu_points=None,
                  return_insitu_points_on_completion=False,
                  templates=None,
+                 grid_cache_dir=None,
                  **kwargs
                 ):
         self.points = points
@@ -105,7 +106,7 @@ class ImageProcessor:
         self._last_persisted_id = 0
         
         # Initialize the KeypointDetector
-        self.keypoint_detector = KeypointDetector(model=model)
+        self.keypoint_detector = KeypointDetector(model=model, cache_dir=grid_cache_dir)
 
         # Initialize trajectory_id column in insitu_points if in validation mode
         if self.insitu_points is not None:

--- a/limosat/keypoint_detector.py
+++ b/limosat/keypoint_detector.py
@@ -9,7 +9,9 @@ import cv2
 import cartopy.crs as ccrs
 from skimage.util import view_as_windows
 from nansat import NSR
-from .utils import log_execution_time, logger
+import os
+from pathlib import Path
+from .utils import log_execution_time, logger, extract_date
 
 class KeypointDetector:
     """
@@ -19,15 +21,17 @@ class KeypointDetector:
     including new keypoint detection and gridded detection.
     """
 
-    def __init__(self, model):
+    def __init__(self, model, debug_recorder=None, cache_dir=None):
         """
         Initialize the keypoint detector.
 
         Parameters:
             model: Feature detection model (e.g., SIFT, ORB)
-            octave (int): The octave value for keypoints
+            debug_recorder: Optional debug recorder for trajectory analysis
+            cache_dir: Optional directory to cache deterministic grid descriptors
         """
         self.model = model
+        self.debug_recorder = debug_recorder
         self.pc = ccrs.PlateCarree()
         central_longitude = -45
         true_scale_latitude = 70
@@ -37,6 +41,86 @@ class KeypointDetector:
         )
         # Cache for precomputed Gaussian masks: key = (window_size, gaussian_sigma_factor)
         self._gaussian_cache = {}
+        # Optional on-disk cache for gridded descriptors
+        if cache_dir is None:
+            cache_dir = os.environ.get("LIMOSAT_GRID_CACHE")
+        self.grid_cache_dir = cache_dir
+        if self.grid_cache_dir:
+            os.makedirs(self.grid_cache_dir, exist_ok=True)
+
+    def _model_cache_tag(self):
+        # Best-effort tag to avoid collisions across detector configs.
+        parts = [self.model.__class__.__name__]
+        for getter, label in (
+            ("getPatchSize", "ps"),
+            ("getNLevels", "nl"),
+            ("getMaxFeatures", "nf"),
+            ("getNFeatures", "nf"),
+            ("getScaleFactor", "sf"),
+            ("getEdgeThreshold", "et"),
+            ("getFirstLevel", "fl"),
+            ("getScoreType", "st"),
+        ):
+            if hasattr(self.model, getter):
+                try:
+                    parts.append(f"{label}{getattr(self.model, getter)()}")
+                except Exception:
+                    pass
+        return "-".join(parts)
+
+    def _cache_subdir(self, img, source_path):
+        date = getattr(img, "date", None)
+        if date is None:
+            date = extract_date(str(source_path))
+        if date is None:
+            return Path("unknown") / "unknown"
+        try:
+            return Path(f"{int(date.year):04d}") / f"{int(date.month):02d}"
+        except Exception:
+            return Path("unknown") / "unknown"
+
+    def _grid_cache_key(self, img, stride, border_size, octave):
+        if not self.grid_cache_dir:
+            return None
+        # Use basename and detector params; attempt to use image filename if available
+        source_path = (
+            getattr(img, "filename", None)
+            or getattr(img, "file_path", None)
+            or getattr(img, "filepath", None)
+            or getattr(img, "name", None)
+            or "unknown"
+        )
+        basename = Path(source_path).stem
+        subdir = self._cache_subdir(img, source_path)
+        model_tag = self._model_cache_tag()
+        return Path(self.grid_cache_dir) / subdir / f"{basename}_s{stride}_b{border_size}_o{octave}_{model_tag}.npz"
+
+    def _load_grid_cache(self, img, stride, border_size, octave):
+        cache_path = self._grid_cache_key(img, stride, border_size, octave)
+        if not cache_path or not cache_path.exists():
+            return None
+        try:
+            with np.load(cache_path, allow_pickle=False) as data:
+                coords = data['coords']
+                descriptors = data['descriptors']
+            tags = [None] * len(coords)
+            return coords, descriptors, tags
+        except Exception as e:
+            logger.warning(f"Failed to load grid cache {cache_path}: {e}")
+            return None
+
+    def _save_grid_cache(self, img, stride, border_size, octave, compute_result):
+        cache_path = self._grid_cache_key(img, stride, border_size, octave)
+        if not cache_path or compute_result is None:
+            return
+        coords, descriptors, tags = compute_result
+        if coords is None or descriptors is None:
+            return
+        try:
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+            np.savez_compressed(cache_path, coords=coords, descriptors=descriptors)
+        except Exception as e:
+            logger.warning(f"Failed to save grid cache {cache_path}: {e}")
         
     @log_execution_time
     def compute_descriptors(self, keypoints_with_tags, img, polarisation='s0_HV', normalize=True):
@@ -301,44 +385,57 @@ class KeypointDetector:
         Returns:
             tuple: (keypoint_coords, descriptors, surviving_tags)
         """
+        # Attempt to load cached grid descriptors
+        cached = self._load_grid_cache(img, stride, border_size, octave)
+        if cached is not None:
+            return cached
+
         # Get image data and replace NaNs with zero
         img0 = img[1]
         img0[np.isnan(img0)] = 0
-        
-        # TODO: generalise preprocessing to create boolean landmask
+
+        # Optional land mask
         landmask = None
         if img.bands().get(2, {'name': 'none'}).get('name') == 'mask':
             landmask = img[2]
             img0[landmask == 2] = 0
 
-        # Generate grid keypoints
-        keypoints = []
-        for r in range(0, img0.shape[0], stride):
-            for c in range(0, img0.shape[1], stride):
-                if landmask is not None and landmask[r, c] == 2:
-                    continue  # skip land cells
+        # Vectorized grid generation to avoid Python double loop
+        h, w = img0.shape
+        rows, cols = np.mgrid[0:h:stride, 0:w:stride]
+        rows_flat = rows.ravel()
+        cols_flat = cols.ravel()
 
-                # The size parameter is required, but will be overwritten by the detector's patch size
-                kp = cv2.KeyPoint(c, r, size=31, octave=octave, angle=img.angle)
+        if landmask is not None:
+            landmask_bool = (landmask == 2)
+            valid_mask = ~landmask_bool[rows_flat, cols_flat]
+            rows_flat = rows_flat[valid_mask]
+            cols_flat = cols_flat[valid_mask]
 
-                keypoints.append((kp, None)) # Append tuple with None as tag
+        # Border filtering in one pass
+        border_mask = (
+            (cols_flat >= border_size)
+            & (cols_flat <= w - border_size)
+            & (rows_flat >= border_size)
+            & (rows_flat <= h - border_size)
+        )
+        rows_flat = rows_flat[border_mask]
+        cols_flat = cols_flat[border_mask]
 
-        # Filter keypoints within image borders
-        filtered_keypoints_with_tags = [
-            item
-            for item in keypoints
-            if (
-                border_size <= item[0].pt[0] <= img0.shape[1] - border_size
-                and border_size <= item[0].pt[1] <= img0.shape[0] - border_size
-            )
+        keypoints_with_tags = [
+            (cv2.KeyPoint(float(c), float(r), size=31, octave=octave, angle=img.angle), None)
+            for r, c in zip(rows_flat, cols_flat)
         ]
 
-        return self.compute_descriptors(
-            filtered_keypoints_with_tags,
+        result = self.compute_descriptors(
+            keypoints_with_tags,
             img,
             polarisation=1,
             normalize=False
         )
+
+        self._save_grid_cache(img, stride, border_size, octave, result)
+        return result
 
     def get_pixel_coords(self, nansat_obj, geom_x, geom_y):
         # helper function for keypoint_from_point

--- a/limosat/keypoint_detector.py
+++ b/limosat/keypoint_detector.py
@@ -21,17 +21,15 @@ class KeypointDetector:
     including new keypoint detection and gridded detection.
     """
 
-    def __init__(self, model, debug_recorder=None, cache_dir=None):
+    def __init__(self, model, cache_dir=None):
         """
         Initialize the keypoint detector.
 
         Parameters:
             model: Feature detection model (e.g., SIFT, ORB)
-            debug_recorder: Optional debug recorder for trajectory analysis
             cache_dir: Optional directory to cache deterministic grid descriptors
         """
         self.model = model
-        self.debug_recorder = debug_recorder
         self.pc = ccrs.PlateCarree()
         central_longitude = -45
         true_scale_latitude = 70

--- a/limosat/precompute_grid_descriptors.py
+++ b/limosat/precompute_grid_descriptors.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""
+Precompute gridded descriptors cache for a catalog of processed Sentinel-1 images.
+
+Usage:
+  python3 -m limosat.precompute_grid_descriptors /path/to/config.yaml
+"""
+
+import argparse
+import os
+from pathlib import Path
+import sys
+import yaml
+
+from concurrent.futures import ProcessPoolExecutor
+import multiprocessing as mp
+
+import cv2
+import geopandas as gpd
+
+# Allow direct execution: ensure package root is on sys.path.
+if __package__ is None:
+    pkg_root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(pkg_root))
+
+from limosat.image import Image
+from limosat.keypoint_detector import KeypointDetector
+from limosat.utils import extract_date
+
+
+def _build_orb_model(kp_detector_config):
+    orb_params = kp_detector_config.get("orb_params", {})
+    return cv2.ORB_create(
+        nfeatures=orb_params.get("nfeatures", 100),
+        scaleFactor=orb_params.get("scaleFactor", 1.25),
+        nlevels=orb_params.get("nlevels", 5),
+        edgeThreshold=orb_params.get("edgeThreshold", 16),
+        firstLevel=orb_params.get("firstLevel", 0),
+        patchSize=orb_params.get("patchSize", 64),
+        scoreType=getattr(
+            cv2,
+            f"ORB_{orb_params.get('scoreType', 'HARRIS_SCORE').upper()}",
+            cv2.ORB_HARRIS_SCORE,
+        ),
+    )
+
+
+class _CacheProbe:
+    def __init__(self, filename):
+        self.filename = filename
+        self.date = extract_date(filename)
+
+
+def _resolve_paths(catalog_path, gdf):
+    path_col = "filepath" if "filepath" in gdf.columns else "filename"
+    if path_col not in gdf.columns:
+        raise KeyError("Catalog missing 'filepath' or 'filename' column.")
+    base_dir = Path(catalog_path).parent
+    paths = []
+    for val in gdf[path_col].dropna().astype(str).tolist():
+        p = Path(val)
+        if not p.is_absolute():
+            p = (base_dir / p).resolve()
+        paths.append(str(p))
+    return paths
+
+
+def _worker(args):
+    (
+        filepath,
+        kp_detector_config,
+        stride,
+        octave,
+        border_size,
+        cache_dir,
+        skip_existing,
+    ) = args
+
+    cv2.setNumThreads(1)
+    model = _build_orb_model(kp_detector_config)
+    detector = KeypointDetector(model=model, cache_dir=cache_dir)
+
+    if skip_existing and cache_dir:
+        probe = _CacheProbe(filepath)
+        cache_path = detector._grid_cache_key(probe, stride, border_size, octave)
+        if cache_path and cache_path.exists():
+            return "cached", filepath
+
+    if not Path(filepath).exists():
+        return "missing", filepath
+
+    try:
+        img = Image(filepath)
+        detector.detect_gridded_points(
+            img=img,
+            stride=stride,
+            octave=octave,
+            border_size=border_size,
+        )
+        return "ok", filepath
+    except Exception as e:
+        return f"error:{type(e).__name__}", filepath
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Precompute gridded descriptor cache for LiMOSAT."
+    )
+    parser.add_argument("config", type=str, help="Path to config YAML.")
+    parser.add_argument(
+        "--catalog",
+        type=str,
+        default=None,
+        help="Override catalog path (geojson). Defaults to config.",
+    )
+    parser.add_argument(
+        "--max-workers",
+        type=int,
+        default=max(1, (os.cpu_count() or 1) // 2),
+        help="Number of worker processes (default: half of CPU cores).",
+    )
+    parser.add_argument("--limit", type=int, default=None, help="Optional limit.")
+    parser.add_argument(
+        "--start",
+        type=int,
+        default=0,
+        help="Start index for slicing the catalog.",
+    )
+    parser.add_argument(
+        "--no-skip-existing",
+        action="store_true",
+        help="Recompute even if cache exists.",
+    )
+    parser.add_argument(
+        "--start-method",
+        type=str,
+        default="spawn",
+        choices=["spawn", "fork", "forkserver"],
+        help="Multiprocessing start method.",
+    )
+    args = parser.parse_args()
+
+    config_path = Path(args.config)
+    with config_path.open("r") as f:
+        config = yaml.safe_load(f)
+
+    kp_detector_config = config.get("keypoint_detector", {})
+    img_proc_params = config.get("image_processor_params", {})
+
+    cache_dir = kp_detector_config.get("grid_cache_dir")
+    if not cache_dir:
+        print("grid_cache_dir is not set in config. Exiting.", file=sys.stderr)
+        return 2
+
+    catalog_path = args.catalog or config.get("paths", {}).get("image_catalog", {}).get("metadata_path")
+    if not catalog_path:
+        print("Catalog path not provided and not found in config.", file=sys.stderr)
+        return 2
+
+    gdf = gpd.read_file(catalog_path)
+    paths = _resolve_paths(catalog_path, gdf)
+
+    if args.start:
+        paths = paths[args.start:]
+    if args.limit is not None:
+        paths = paths[: args.limit]
+
+    # Deduplicate while preserving order
+    seen = set()
+    deduped = []
+    for p in paths:
+        if p not in seen:
+            seen.add(p)
+            deduped.append(p)
+    paths = deduped
+
+    stride = img_proc_params.get("stride")
+    octave = img_proc_params.get("octave")
+    border_size = img_proc_params.get("border_size")
+    if stride is None or octave is None or border_size is None:
+        print("Missing stride/octave/border_size in image_processor_params.", file=sys.stderr)
+        return 2
+
+    skip_existing = not args.no_skip_existing
+    def task_iter():
+        for p in paths:
+            yield (
+                p,
+                kp_detector_config,
+                stride,
+                octave,
+                border_size,
+                cache_dir,
+                skip_existing,
+            )
+
+    ctx = mp.get_context(args.start_method)
+    ok = cached = missing = errors = 0
+
+    try:
+        from tqdm import tqdm
+        progress = tqdm(total=len(tasks), unit="img")
+    except Exception:
+        progress = None
+
+    with ProcessPoolExecutor(max_workers=args.max_workers, mp_context=ctx) as ex:
+        for status, _ in ex.map(_worker, task_iter(), chunksize=8):
+            if status == "ok":
+                ok += 1
+            elif status == "cached":
+                cached += 1
+            elif status == "missing":
+                missing += 1
+            else:
+                errors += 1
+            if progress:
+                progress.update(1)
+
+    if progress:
+        progress.close()
+
+    print(f"Done. ok={ok}, cached={cached}, missing={missing}, errors={errors}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
added a script precompute_grid_descriptors.py and the ability to read a cache of descriptors, this saves 5-7 seconds per image (50% of processing time)