### PR TITLE
Codex/limosat speed gate pr

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -30,7 +30,7 @@ image_processor_params:
   persist_updates: true
   persist_interval: 100
   pruning_interval: 25
-  temporal_window: 4
+  temporal_window: 4  # days
   max_speed_m_per_day: null
   candidate_search_max_daily_drift_m: 10000
   window_size: 64
@@ -59,7 +59,6 @@ keypoint_detector:
 matcher_params:
   norm_type: "NORM_HAMMING2"
   descriptor_distance_max: 120
-  max_speed_m_per_day: null
   spatial_distance_max: 100000
   model_threshold: 10000
   plot_matches: false

--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -31,6 +31,7 @@ image_processor_params:
   persist_interval: 100
   pruning_interval: 25
   temporal_window: 4
+  max_speed_m_per_day: null
   candidate_search_max_daily_drift_m: 10000
   window_size: 64
   border_size: 128
@@ -58,6 +59,7 @@ keypoint_detector:
 matcher_params:
   norm_type: "NORM_HAMMING2"
   descriptor_distance_max: 120
+  max_speed_m_per_day: null
   spatial_distance_max: 100000
   model_threshold: 10000
   plot_matches: false

--- a/limosat/image_processor.py
+++ b/limosat/image_processor.py
@@ -61,6 +61,7 @@ class ImageProcessor:
             'pruning_interval': 10,
             'temporal_window': 3,
             'convergence_radius_pixels': 5,
+            'max_speed_m_per_day': None,
             'candidate_search_max_daily_drift_m': 10000,
             'window_size': 64,
             'border_size': 128,
@@ -89,7 +90,14 @@ class ImageProcessor:
         self.pruning_interval = proc_params['pruning_interval']
         self.temporal_window = proc_params['temporal_window']
         self.convergence_radius_pixels = proc_params['convergence_radius_pixels']
-        self.candidate_search_max_daily_drift_m = proc_params['candidate_search_max_daily_drift_m']
+        self.max_speed_m_per_day = proc_params.get('max_speed_m_per_day')
+        if self.max_speed_m_per_day is not None:
+            self.max_speed_m_per_day = float(self.max_speed_m_per_day)
+        self.candidate_search_max_daily_drift_m = (
+            self.max_speed_m_per_day
+            if self.max_speed_m_per_day is not None
+            else proc_params['candidate_search_max_daily_drift_m']
+        )
         self.window_size = proc_params['window_size']
         self.border_size = proc_params['border_size']
         self.border_matched = proc_params['border_matched']
@@ -101,9 +109,16 @@ class ImageProcessor:
         self.template_size = proc_params['template_size']
         self.use_interpolation = proc_params['use_interpolation']
         self.max_interpolation_time_gap_hours = proc_params['max_interpolation_time_gap_hours']
-        self.max_valid_speed_m_per_day = proc_params['max_valid_speed_m_per_day']
+        self.max_valid_speed_m_per_day = (
+            self.max_speed_m_per_day
+            if self.max_speed_m_per_day is not None
+            else proc_params['max_valid_speed_m_per_day']
+        )
         self.window_border = proc_params['window_border']  # 0 disables weighting
         self._last_persisted_id = 0
+
+        if self.matcher is not None and self.max_speed_m_per_day is not None:
+            self.matcher.max_speed_m_per_day = self.max_speed_m_per_day
         
         # Initialize the KeypointDetector
         self.keypoint_detector = KeypointDetector(model=model, cache_dir=grid_cache_dir)
@@ -126,6 +141,16 @@ class ImageProcessor:
         if self.insitu_points is not None:
             logger.info("Validation mode enabled with in-situ points")
 
+    def _candidate_buffer_distance_m(self):
+        max_possible_drift = self.candidate_search_max_daily_drift_m * self.temporal_window
+        if self.max_speed_m_per_day is not None or self.matcher is None:
+            return max_possible_drift
+
+        spatial_distance_max = getattr(self.matcher, 'spatial_distance_max', None)
+        if spatial_distance_max is None or not np.isfinite(spatial_distance_max) or spatial_distance_max <= 0:
+            return max_possible_drift
+        return min(max_possible_drift, spatial_distance_max)
+
     def process_image(self, image_id, filename):
         """Process a single image: match existing trajectories, seed new points, update templates, optionally persist.
 
@@ -144,15 +169,7 @@ class ImageProcessor:
         img = Image(filename)
         
         # Compute buffer allowing drift INTO current frame
-        max_possible_drift = self.candidate_search_max_daily_drift_m * self.temporal_window
-        buffer_distance = min(max_possible_drift, self.matcher.spatial_distance_max)
-        logger.debug(
-            "Using buffer distance: %.2f km (max theo %.1f km over %d days, match limit %.1f km)",
-            buffer_distance / 1000.0,
-            max_possible_drift / 1000.0,
-            self.temporal_window,
-            self.matcher.spatial_distance_max / 1000.0,
-        )
+        buffer_distance = self._candidate_buffer_distance_m()
         buffered_image_poly = img.poly.buffer(buffer_distance)
         time_threshold = img.date - pd.Timedelta(days=self.temporal_window)
         points_last = self.points.last()

--- a/limosat/image_processor.py
+++ b/limosat/image_processor.py
@@ -103,7 +103,7 @@ class ImageProcessor:
             self.max_speed_m_per_day = matcher_max_speed
         elif matcher_max_speed is not None and matcher_max_speed != self.max_speed_m_per_day:
             raise ValueError("max_speed_m_per_day must not be set to different values on ImageProcessor and Matcher.")
-        # Use one motion-control value for admission, matching, and final filtering.
+        # Use one motion-control value for candidate buffering, matching, and final filtering.
         self.candidate_search_max_daily_drift_m = (
             self.max_speed_m_per_day
             if self.max_speed_m_per_day is not None
@@ -180,7 +180,7 @@ class ImageProcessor:
         # Create Nansat Image object from file
         img = Image(filename)
         
-        # Compute buffer allowing drift INTO current frame
+        # Compute the candidate buffer for points that could drift into the current frame.
         buffer_distance = self._candidate_buffer_distance_m()
         buffered_image_poly = img.poly.buffer(buffer_distance)
         time_threshold = img.date - pd.Timedelta(days=self.temporal_window)

--- a/limosat/image_processor.py
+++ b/limosat/image_processor.py
@@ -88,11 +88,22 @@ class ImageProcessor:
         self.persist_updates = proc_params['persist_updates']
         self.persist_interval = proc_params['persist_interval']
         self.pruning_interval = proc_params['pruning_interval']
+        # temporal_window is measured in days.
         self.temporal_window = proc_params['temporal_window']
         self.convergence_radius_pixels = proc_params['convergence_radius_pixels']
         self.max_speed_m_per_day = proc_params.get('max_speed_m_per_day')
         if self.max_speed_m_per_day is not None:
             self.max_speed_m_per_day = float(self.max_speed_m_per_day)
+        matcher_max_speed = None
+        if self.matcher is not None:
+            matcher_max_speed = getattr(self.matcher, 'max_speed_m_per_day', None)
+            if matcher_max_speed is not None:
+                matcher_max_speed = float(matcher_max_speed)
+        if self.max_speed_m_per_day is None:
+            self.max_speed_m_per_day = matcher_max_speed
+        elif matcher_max_speed is not None and matcher_max_speed != self.max_speed_m_per_day:
+            raise ValueError("max_speed_m_per_day must not be set to different values on ImageProcessor and Matcher.")
+        # Use one motion-control value for admission, matching, and final filtering.
         self.candidate_search_max_daily_drift_m = (
             self.max_speed_m_per_day
             if self.max_speed_m_per_day is not None
@@ -142,6 +153,7 @@ class ImageProcessor:
             logger.info("Validation mode enabled with in-situ points")
 
     def _candidate_buffer_distance_m(self):
+        # temporal_window is a day-based lookback, so this is meters/day * days.
         max_possible_drift = self.candidate_search_max_daily_drift_m * self.temporal_window
         if self.max_speed_m_per_day is not None or self.matcher is None:
             return max_possible_drift

--- a/limosat/keypoints.py
+++ b/limosat/keypoints.py
@@ -13,6 +13,18 @@ from .utils import log_execution_time
 class Keypoints(gpd.GeoDataFrame):
     srs = NSR(3413)
 
+    @staticmethod
+    def _normalize_stopped(series):
+        """Normalize stopped flags to non-null bool values."""
+        return series.fillna(False).astype(bool)
+
+    @staticmethod
+    def _normalize_converged_to(series):
+        """Normalize converged_to to nullable integer trajectory ids."""
+        numeric = pd.to_numeric(series, errors='coerce')
+        numeric = numeric.mask(numeric == -1, pd.NA)
+        return numeric.astype('Int64')
+
     def __init__(self, *args, **kwargs):
         if not args and not kwargs:
             # Initialize with empty data if no arguments provided
@@ -40,13 +52,13 @@ class Keypoints(gpd.GeoDataFrame):
             if 'time' in self.columns:
                 self['time'] = pd.to_datetime(self['time'], errors='coerce')
             if 'stopped' in self.columns:
-                self['stopped'] = self['stopped'].astype(bool)
+                self['stopped'] = self._normalize_stopped(self['stopped'])
             if 'interpolated' in self.columns:
                 self['interpolated'] = self['interpolated'].astype('int32')
             if 'trajectory_id' in self.columns:
                 self['trajectory_id'] = self['trajectory_id'].astype('int64')
             if 'converged_to' in self.columns:
-                self['converged_to'] = self['converged_to'].astype('Int64')
+                self['converged_to'] = self._normalize_converged_to(self['converged_to'])
         else:
             # Initialize with provided data
             super().__init__(*args, **kwargs)
@@ -58,10 +70,9 @@ class Keypoints(gpd.GeoDataFrame):
             if 'trajectory_id' in self.columns:
                 self['trajectory_id'] = self['trajectory_id'].astype('int64', errors='ignore')
             if 'stopped' in self.columns:
-                self['stopped'] = self['stopped'].astype(bool)
+                self['stopped'] = self._normalize_stopped(self['stopped'])
             if 'converged_to' in self.columns:
-                self.loc[self['converged_to'] == -1, 'converged_to'] = pd.NA
-                self['converged_to'] = self['converged_to'].astype('Int64')
+                self['converged_to'] = self._normalize_converged_to(self['converged_to'])
             if 'interpolated' in self.columns:
                 self['interpolated'] = self['interpolated'].astype('int64', errors='ignore')
             if 'orbit_num' in self.columns:

--- a/limosat/matcher.py
+++ b/limosat/matcher.py
@@ -6,6 +6,7 @@
 
 import numpy as np
 import cv2
+import pandas as pd
 from skimage.transform import AffineTransform
 from matplotlib import pyplot as plt
 from collections import defaultdict
@@ -68,6 +69,15 @@ class Matcher:
         plt.colorbar(qui, ax=axs[0], shrink=0.5)
         plt.show()
 
+    @staticmethod
+    def _single_time_value(times, context):
+        valid_times = pd.Series(times).dropna().unique()
+        if len(valid_times) == 0:
+            return None
+        if len(valid_times) != 1:
+            raise ValueError(f"{context} must contain exactly one timestamp.")
+        return pd.Timestamp(valid_times[0])
+
     @log_execution_time
     def match_with_grid(self, points_poly, points_grid):
         """
@@ -105,12 +115,17 @@ class Matcher:
 
         # 4. Loop through each group and apply the 'filter' function
         all_inliers_idx0, all_inliers_idx1, all_residuals = [], [], []
-        current_time = points_grid.iloc[0]['time'] if 'time' in points_grid.columns and len(points_grid) > 0 else None
+        current_time = None
+        if 'time' in points_grid.columns and len(points_grid) > 0:
+            current_time = self._single_time_value(points_grid['time'], "Current frame points")
         for image_id, group_matches in matches_by_group.items():
             previous_time = None
-            if current_time is not None and len(group_matches) > 0:
-                # Each group references one previous image, so the first match time represents the group.
-                previous_time = points_poly.iloc[group_matches[0].queryIdx]['time']
+            if current_time is not None and len(group_matches) > 0 and 'time' in points_poly.columns:
+                group_query_idx = [match.queryIdx for match in group_matches]
+                previous_time = self._single_time_value(
+                    points_poly.iloc[group_query_idx]['time'],
+                    f"Matches for previous image_id {image_id}",
+                )
             max_distance_m = self.motion_distance_limit(previous_time, current_time)
             rc_idx0_group, rc_idx1_group, residuals_group = self.filter(
                 group_matches,

--- a/limosat/matcher.py
+++ b/limosat/matcher.py
@@ -109,6 +109,7 @@ class Matcher:
         for image_id, group_matches in matches_by_group.items():
             previous_time = None
             if current_time is not None and len(group_matches) > 0:
+                # Each group references one previous image, so the first match time represents the group.
                 previous_time = points_poly.iloc[group_matches[0].queryIdx]['time']
             max_distance_m = self.motion_distance_limit(previous_time, current_time)
             rc_idx0_group, rc_idx1_group, residuals_group = self.filter(
@@ -224,12 +225,12 @@ class Matcher:
             if not self.use_model_estimation: return dd_idx0, dd_idx1, None
             return None, None, None
         
-        if max_distance_m is not None and np.isfinite(max_distance_m) and max_distance_m > 0:
+        if max_distance_m is not None and np.isfinite(max_distance_m) and max_distance_m >= 0:
             current_spatial_distances = np.hypot(
                 pos1[dd_idx1, 0] - pos0[dd_idx0, 0],
                 pos1[dd_idx1, 1] - pos0[dd_idx0, 1],
             )
-            gpi1_spatial_filter_mask = current_spatial_distances < max_distance_m
+            gpi1_spatial_filter_mask = current_spatial_distances <= max_distance_m
             md_idx0 = dd_idx0[gpi1_spatial_filter_mask]
             md_idx1 = dd_idx1[gpi1_spatial_filter_mask]
         else:

--- a/limosat/matcher.py
+++ b/limosat/matcher.py
@@ -17,6 +17,7 @@ class Matcher:
                  norm=cv2.NORM_HAMMING2,
                  descriptor_distance_max=120,
                  spatial_distance_max=100000,
+                 max_speed_m_per_day=None,
 
                  # Homography estimation parameters
                  model=AffineTransform,
@@ -36,6 +37,7 @@ class Matcher:
         self.norm = norm
         self.descriptor_distance_max = descriptor_distance_max
         self.spatial_distance_max = spatial_distance_max
+        self.max_speed_m_per_day = max_speed_m_per_day
 
         # Homography estimation parameters
         self.model = model
@@ -103,8 +105,18 @@ class Matcher:
 
         # 4. Loop through each group and apply the 'filter' function
         all_inliers_idx0, all_inliers_idx1, all_residuals = [], [], []
+        current_time = points_grid.iloc[0]['time'] if 'time' in points_grid.columns and len(points_grid) > 0 else None
         for image_id, group_matches in matches_by_group.items():
-            rc_idx0_group, rc_idx1_group, residuals_group = self.filter(group_matches, pos0, pos1)
+            previous_time = None
+            if current_time is not None and len(group_matches) > 0:
+                previous_time = points_poly.iloc[group_matches[0].queryIdx]['time']
+            max_distance_m = self.motion_distance_limit(previous_time, current_time)
+            rc_idx0_group, rc_idx1_group, residuals_group = self.filter(
+                group_matches,
+                pos0,
+                pos1,
+                max_distance_m=max_distance_m,
+            )
             
             if rc_idx0_group is not None and rc_idx0_group.size > 0:
                 all_inliers_idx0.append(rc_idx0_group)
@@ -189,8 +201,16 @@ class Matcher:
         
         return combined_matches
 
+    def motion_distance_limit(self, previous_time=None, current_time=None):
+        if self.max_speed_m_per_day is not None and previous_time is not None and current_time is not None:
+            delta_t_days = max((current_time - previous_time).total_seconds() / 86400.0, 0.0)
+            return float(self.max_speed_m_per_day) * delta_t_days
+        if self.spatial_distance_max is None:
+            return None
+        return float(self.spatial_distance_max)
+
     @log_execution_time
-    def filter(self, matches, pos0, pos1):
+    def filter(self, matches, pos0, pos1, max_distance_m=None):
         bf_idx0 = np.array([m.queryIdx for m in matches]) # Indices into pos0 for ALL 'matches'
         bf_idx1 = np.array([m.trainIdx for m in matches]) # Indices into pos1 for ALL 'matches'
 
@@ -204,13 +224,17 @@ class Matcher:
             if not self.use_model_estimation: return dd_idx0, dd_idx1, None
             return None, None, None
         
-        # Filter by spatial distance
-        # Calculate spatial distances ONLY for those that passed the descriptor distance filter
-        current_spatial_distances = np.hypot(pos1[dd_idx1, 0] - pos0[dd_idx0, 0], 
-                                            pos1[dd_idx1, 1] - pos0[dd_idx0, 1])
-        gpi1_spatial_filter_mask = current_spatial_distances < self.spatial_distance_max # Mask relative to dd_idx arrays
-        md_idx0 = dd_idx0[gpi1_spatial_filter_mask] # Indices of points passing spatial (and descriptor) filter
-        md_idx1 = dd_idx1[gpi1_spatial_filter_mask]
+        if max_distance_m is not None and np.isfinite(max_distance_m) and max_distance_m > 0:
+            current_spatial_distances = np.hypot(
+                pos1[dd_idx1, 0] - pos0[dd_idx0, 0],
+                pos1[dd_idx1, 1] - pos0[dd_idx0, 1],
+            )
+            gpi1_spatial_filter_mask = current_spatial_distances < max_distance_m
+            md_idx0 = dd_idx0[gpi1_spatial_filter_mask]
+            md_idx1 = dd_idx1[gpi1_spatial_filter_mask]
+        else:
+            md_idx0 = dd_idx0
+            md_idx1 = dd_idx1
 
         if not self.use_model_estimation:
             return md_idx0, md_idx1, None # md_idx0, md_idx1 are the final indices if no model estimation

--- a/tests/unit/test_motion_limits.py
+++ b/tests/unit/test_motion_limits.py
@@ -80,6 +80,24 @@ def test_matcher_filter_respects_motion_distance_limit():
 
 
 @pytest.mark.unit
+def test_matcher_filter_zero_motion_limit_keeps_only_exact_matches():
+    Matcher = load_real_module("limosat.matcher").Matcher
+
+    matcher = Matcher(descriptor_distance_max=100, use_model_estimation=False)
+    matches = [
+        cv2.DMatch(_queryIdx=0, _trainIdx=0, _distance=10),
+        cv2.DMatch(_queryIdx=1, _trainIdx=1, _distance=10),
+    ]
+    pos0 = np.array([[0.0, 0.0], [0.0, 0.0]], dtype=float)
+    pos1 = np.array([[0.0, 0.0], [0.1, 0.0]], dtype=float)
+
+    idx0, idx1, _ = matcher.filter(matches, pos0, pos1, max_distance_m=0.0)
+
+    assert idx0.tolist() == [0]
+    assert idx1.tolist() == [0]
+
+
+@pytest.mark.unit
 def test_image_processor_max_speed_sets_all_motion_limits():
     ImageProcessor = load_real_module("limosat.image_processor").ImageProcessor
 

--- a/tests/unit/test_motion_limits.py
+++ b/tests/unit/test_motion_limits.py
@@ -156,6 +156,44 @@ def test_image_processor_max_speed_sets_all_motion_limits():
 
 
 @pytest.mark.unit
+def test_image_processor_reuses_matcher_max_speed_when_processor_value_is_unset():
+    ImageProcessor = load_real_module("limosat.image_processor").ImageProcessor
+
+    matcher = MatcherStub()
+    matcher.max_speed_m_per_day = 40000
+    proc = ImageProcessor(
+        points=make_points(),
+        model=None,
+        matcher=matcher,
+        persist_updates=False,
+        temporal_window=3,
+    )
+
+    assert proc.max_speed_m_per_day == pytest.approx(40000.0)
+    assert proc.candidate_search_max_daily_drift_m == pytest.approx(40000.0)
+    assert proc.max_valid_speed_m_per_day == pytest.approx(40000.0)
+    assert proc.matcher.max_speed_m_per_day == pytest.approx(40000.0)
+
+
+@pytest.mark.unit
+def test_image_processor_rejects_conflicting_max_speed_values():
+    ImageProcessor = load_real_module("limosat.image_processor").ImageProcessor
+
+    matcher = MatcherStub()
+    matcher.max_speed_m_per_day = 40000
+
+    with pytest.raises(ValueError, match="must not be set to different values"):
+        ImageProcessor(
+            points=make_points(),
+            model=None,
+            matcher=matcher,
+            persist_updates=False,
+            temporal_window=3,
+            max_speed_m_per_day=50000,
+        )
+
+
+@pytest.mark.unit
 def test_image_processor_buffer_uses_spatial_cap_without_max_speed():
     ImageProcessor = load_real_module("limosat.image_processor").ImageProcessor
 

--- a/tests/unit/test_motion_limits.py
+++ b/tests/unit/test_motion_limits.py
@@ -8,7 +8,7 @@ import pandas as pd
 import pytest
 from shapely.geometry import Point
 
-from tests.factories import MatcherStub
+from tests.factories import MatcherStub, make_keypoints
 
 
 def load_real_module(module_name):
@@ -95,6 +95,44 @@ def test_matcher_filter_zero_motion_limit_keeps_only_exact_matches():
 
     assert idx0.tolist() == [0]
     assert idx1.tolist() == [0]
+
+
+@pytest.mark.unit
+def test_matcher_rejects_mixed_previous_times_within_group():
+    Matcher = load_real_module("limosat.matcher").Matcher
+
+    matcher = Matcher(descriptor_distance_max=100, use_model_estimation=False, max_speed_m_per_day=50000)
+    points_poly = make_keypoints(2, image_id=1, t0="2020-03-01 00:00:00", step_s=3600)
+    points_grid = make_keypoints(2, image_id=2, t0="2020-03-02 00:00:00", step_s=0)
+    matches = [
+        cv2.DMatch(_queryIdx=0, _trainIdx=0, _distance=10),
+        cv2.DMatch(_queryIdx=1, _trainIdx=1, _distance=10),
+    ]
+
+    matcher.match_with_crosscheck = lambda x0, x1: matches
+    matcher.match_with_lowe_ratio = lambda matches_bf_initial, x0, x1, pos0, pos1: matches_bf_initial
+
+    with pytest.raises(ValueError, match="previous image_id 1"):
+        matcher.match_with_grid(points_poly, points_grid)
+
+
+@pytest.mark.unit
+def test_matcher_rejects_mixed_current_frame_times():
+    Matcher = load_real_module("limosat.matcher").Matcher
+
+    matcher = Matcher(descriptor_distance_max=100, use_model_estimation=False, max_speed_m_per_day=50000)
+    points_poly = make_keypoints(2, image_id=1, t0="2020-03-01 00:00:00", step_s=0)
+    points_grid = make_keypoints(2, image_id=2, t0="2020-03-02 00:00:00", step_s=3600)
+    matches = [
+        cv2.DMatch(_queryIdx=0, _trainIdx=0, _distance=10),
+        cv2.DMatch(_queryIdx=1, _trainIdx=1, _distance=10),
+    ]
+
+    matcher.match_with_crosscheck = lambda x0, x1: matches
+    matcher.match_with_lowe_ratio = lambda matches_bf_initial, x0, x1, pos0, pos1: matches_bf_initial
+
+    with pytest.raises(ValueError, match="Current frame points"):
+        matcher.match_with_grid(points_poly, points_grid)
 
 
 @pytest.mark.unit

--- a/tests/unit/test_motion_limits.py
+++ b/tests/unit/test_motion_limits.py
@@ -1,0 +1,118 @@
+import importlib
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pandas as pd
+import pytest
+from shapely.geometry import Point
+
+from tests.factories import MatcherStub
+
+
+def load_real_module(module_name):
+    repo_root = Path(__file__).resolve().parents[2]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+    for name in list(sys.modules):
+        if name == "limosat" or name.startswith("limosat."):
+            del sys.modules[name]
+    return importlib.import_module(module_name)
+
+
+def make_points():
+    Keypoints = load_real_module("limosat.keypoints").Keypoints
+
+    return Keypoints(
+        {
+            "trajectory_id": [0],
+            "image_id": [1],
+            "is_last": [1],
+            "stopped": [False],
+            "converged_to": [None],
+            "time": [pd.Timestamp("2020-03-01 00:00:00")],
+        },
+        geometry=[Point(0, 0)],
+        crs="EPSG:3413",
+    )
+
+
+@pytest.mark.unit
+def test_matcher_motion_distance_limit_scales_with_time_gap():
+    Matcher = load_real_module("limosat.matcher").Matcher
+
+    matcher = Matcher(max_speed_m_per_day=50000, use_model_estimation=False)
+    previous_time = pd.Timestamp("2020-03-01 00:00:00")
+
+    assert matcher.motion_distance_limit(previous_time, previous_time + pd.Timedelta(hours=12)) == pytest.approx(25000.0)
+    assert matcher.motion_distance_limit(previous_time, previous_time + pd.Timedelta(days=3)) == pytest.approx(150000.0)
+
+
+@pytest.mark.unit
+def test_matcher_motion_distance_limit_clamps_backward_time_gap():
+    Matcher = load_real_module("limosat.matcher").Matcher
+
+    matcher = Matcher(max_speed_m_per_day=50000, spatial_distance_max=100000, use_model_estimation=False)
+
+    assert matcher.motion_distance_limit(
+        pd.Timestamp("2020-03-13 00:00:00"),
+        pd.Timestamp("2020-03-03 00:00:00"),
+    ) == pytest.approx(0.0)
+
+
+@pytest.mark.unit
+def test_matcher_filter_respects_motion_distance_limit():
+    Matcher = load_real_module("limosat.matcher").Matcher
+
+    matcher = Matcher(descriptor_distance_max=100, use_model_estimation=False)
+    matches = [
+        cv2.DMatch(_queryIdx=0, _trainIdx=0, _distance=10),
+        cv2.DMatch(_queryIdx=1, _trainIdx=1, _distance=10),
+    ]
+    pos0 = np.array([[0.0, 0.0], [0.0, 0.0]], dtype=float)
+    pos1 = np.array([[30.0, 0.0], [60.0, 0.0]], dtype=float)
+
+    idx0, idx1, _ = matcher.filter(matches, pos0, pos1, max_distance_m=50.0)
+
+    assert idx0.tolist() == [0]
+    assert idx1.tolist() == [0]
+
+
+@pytest.mark.unit
+def test_image_processor_max_speed_sets_all_motion_limits():
+    ImageProcessor = load_real_module("limosat.image_processor").ImageProcessor
+
+    matcher = MatcherStub()
+    proc = ImageProcessor(
+        points=make_points(),
+        model=None,
+        matcher=matcher,
+        persist_updates=False,
+        temporal_window=3,
+        max_speed_m_per_day=50000,
+    )
+
+    assert proc.candidate_search_max_daily_drift_m == pytest.approx(50000.0)
+    assert proc.max_valid_speed_m_per_day == pytest.approx(50000.0)
+    assert proc.matcher.max_speed_m_per_day == pytest.approx(50000.0)
+    assert proc._candidate_buffer_distance_m() == pytest.approx(150000.0)
+
+
+@pytest.mark.unit
+def test_image_processor_buffer_uses_spatial_cap_without_max_speed():
+    ImageProcessor = load_real_module("limosat.image_processor").ImageProcessor
+
+    matcher = MatcherStub()
+    matcher.spatial_distance_max = 15000
+    proc = ImageProcessor(
+        points=make_points(),
+        model=None,
+        matcher=matcher,
+        persist_updates=False,
+        temporal_window=3,
+        candidate_search_max_daily_drift_m=10000,
+        max_valid_speed_m_per_day=50000,
+    )
+
+    assert proc._candidate_buffer_distance_m() == pytest.approx(15000.0)


### PR DESCRIPTION
This change replaces the fixed inter-frame distance cap with a time-aware motion limit, `max_speed_m_per_day * Δt`, so the motion prior stays physically consistent across revisit gaps. A fixed `25 km` cap does not correspond to one speed assumption; it implies very different effective speeds depending on cadence, from roughly `74 km/day` on an `8 h` gap to about `8 km/day` on a `3 day` gap. The speed-based gate asks the more defensible question: what physically justified speed threshold also gives acceptable matcher behavior?

`max_speed_m_per_day` is intended to be the single motion-control parameter, applied consistently at trajectory admission, matcher filtering, and final post-match velocity filtering. We chose the working value by combining physical plausibility with downstream tracking behavior: use a defensible upper-bound ice speed, then check which value preserves strong long-tail persistence without destabilizing the matcher. In the legacy benchmark sweep, `35 km/day` was the best aggregate compromise among the tested speed values, with the largest benefit on irregular-gap sequences where the fixed-distance gate is least meaningful.

| Setting | Gmean objective | Effective long tracks | Near-complete tracks | Median NN distance (m) |
| --- | ---: | ---: | ---: | ---: |
| Best fixed baseline (`25 km`) | 0.1922 | 476.7 | 334.3 | 7779.7 |
| Best speed setting (`35 km/day`) | 0.2198 | 555.1 | 447.1 | 7676.3 |
| Relative change | +14.4% | +16.4% | +33.7% | -1.3% |
